### PR TITLE
docs: Extract enterprise CLI design documentation from PR #41

### DIFF
--- a/arc/cli/ENTERPRISE_CLI_DESIGN_PHILOSOPHY.md
+++ b/arc/cli/ENTERPRISE_CLI_DESIGN_PHILOSOPHY.md
@@ -1,0 +1,170 @@
+# Arc Enterprise CLI Design Philosophy
+
+## Core Philosophy: From Analysis to Action Through Continuous Improvement
+
+Arc's CLI interface is designed around a fundamental principle: **Understanding what to do next**. Every output, visualization, and recommendation is crafted to help ML Engineers and AI PMs quickly identify false assumptions in their AI agents and take concrete actions to improve them through a continuous improvement loop.
+
+The Arc workflow transforms capability gaps into validated improvements:
+```
+Discover → Analyze → Recommend → Validate → Improve → Repeat
+```
+
+## Design Principles
+
+### 1. Assumption Validation First
+**"Great evals tell you which of your assumptions are false"**
+
+- **Surface Hidden Assumptions**: Clearly highlight when agents assume USD, English-only, or other implicit defaults
+- **Decompose Failures**: Show the exact step in the agent pipeline where assumptions break down
+- **Minimal Reproductions**: Reduce complex failures to their simplest form that exposes the false assumption
+
+### 2. Capability Decomposition
+**"Decompose your capability into as many meaningful steps as possible"**
+
+- **Funnel Analysis**: Display agent execution as a series of steps, showing where failures occur
+- **Multi-Tool Chain Tracking**: Decompose complex agent workflows across tool boundaries
+- **Error Origin Tracking**: Identify root causes, not just end symptoms
+- **Step-by-Step Reliability**: Show success rates at each stage of agent execution
+- **Tool Call Analysis**: Highlight failures in tool selection, parameter passing, and response handling
+
+### 3. Infrastructure Over Intelligence
+**"Often the solution isn't making AI better - it's building the right supporting infrastructure"**
+
+- **Prioritize System Fixes**: Recommend configuration changes before model changes
+- **Multi-Model Intelligence**: Show when switching models is actually the answer
+- **Tool & Context Improvements**: Highlight when better prompts or tools solve the problem
+
+### 4. Rapid Iteration Cycles
+**"Move twice as quickly without sacrificing precision"**
+
+- **5-Minute Feedback Loop**: From configuration to actionable insights
+- **Side-by-Side Comparisons**: A/B testing with statistical validation
+- **Progressive Disclosure**: Show key metrics first, details on demand
+
+### 5. Measurable Impact
+**"You can only manage what you can measure"**
+
+- **Statistical Rigor**: Every claim backed by p-values and confidence intervals
+- **Business Metrics**: Translate reliability improvements to dollar impact
+- **Trend Visualization**: Show improvement over time with clear charts
+- **Diff Acceptance Tracking**: Learn from which recommendations users actually implement
+- **Capability Score Evolution**: Track how each capability improves across iterations
+
+## Implementation Guidelines
+
+### Visual Hierarchy
+1. **Primary Insight** - The most important finding (e.g., "Currency assumptions cause 86% of failures")
+2. **Business Impact** - What this means in dollars and risk
+3. **Actionable Fix** - Specific configuration change with expected outcome
+4. **Supporting Data** - Statistical validation, trend charts, detailed breakdowns
+
+### Information Density
+- **Overview First**: One-line summaries before detailed panels
+- **Progressive Detail**: Collapsed sections that expand on demand
+- **Scannable Output**: Key metrics in consistent positions across commands
+
+### Real-Time Feedback
+- **Live Progress**: Streaming updates during execution
+- **Partial Results**: Show findings as they emerge
+- **Cost Tracking**: Running total of execution costs
+
+### Actionability Score
+Every recommendation includes:
+- **Implementation Time**: "10 minutes" vs "2 hours"
+- **Confidence Level**: Based on historical data and diff acceptance rates
+- **Expected Impact**: Quantified improvement
+- **Verification Method**: How to validate the fix works
+
+### Continuous Improvement Tracking
+- **Improvement History**: Show which past recommendations were accepted and their impact
+- **Learning Signals**: Track which fixes actually improved capabilities
+- **Pattern Recognition**: Surface recurring issues across multiple agents
+- **Network Effects**: Highlight when fixes from other agents apply
+
+## Target Personas
+
+### ML Engineer
+- **Needs**: Quick identification of failure patterns, clear fixes
+- **Values**: Statistical rigor, performance metrics, cost efficiency
+- **Output Focus**: Technical details with business context
+
+### Technical AI PM
+- **Needs**: Business impact, ROI justification, risk assessment
+- **Values**: Reliability improvements, cost reduction, time savings
+- **Output Focus**: Executive summaries with drill-down capability
+
+## Command-Specific Philosophy
+
+### `arc run`
+**Purpose**: Proactive discovery of capability gaps
+- Show real-time discovery of issues
+- Emphasize "found BEFORE production"
+- Track cost and performance throughout
+
+### `arc analyze`
+**Purpose**: Understand the origin of failure
+- Decompose into failure clusters
+- Show minimal reproductions
+- Identify systemic vs isolated issues
+
+### `arc recommend`
+**Purpose**: From analysis to action
+- Prioritize infrastructure fixes
+- Show multi-model alternatives
+- Quantify expected improvements
+
+### `arc diff`
+**Purpose**: Validate assumptions with data
+- Statistical validation of improvements
+- Side-by-side performance comparison
+- Business impact quantification
+
+### `arc status`
+**Purpose**: Manage what you measure
+- Track improvement trends
+- Identify optimization opportunities
+- Show cumulative value delivered
+
+## Anti-Patterns to Avoid
+
+1. **Information Overload**: Don't show 50 scenarios when 5 tell the story
+2. **Technical Jargon**: Translate to business impact
+3. **Vague Recommendations**: Every suggestion must be specific and actionable
+4. **Unsubstantiated Claims**: No improvement claims without statistical backing
+5. **Model-First Thinking**: Don't recommend model changes when config fixes work
+
+## Success Metrics
+
+An interface succeeds when:
+1. Users identify root causes in < 30 seconds
+2. Recommendations have > 80% acceptance rate
+3. Time from problem to fix is < 5 minutes
+4. Users trust the statistical validation
+5. Business value is immediately apparent
+
+## Enterprise Features (Future Roadmap)
+
+While the MVP focuses on immediate value, the design supports future enterprise capabilities:
+
+### Compliance and Audit Trail
+- **Signed Attestations**: Export reliability reports with cryptographic signatures
+- **Change History**: Complete audit trail of all configuration modifications
+- **Compliance Mapping**: Map improvements to SOC 2, ISO 27001 requirements
+- **Report Generation**: PDF/JSON exports for governance workflows
+
+### Multi-Tool Agent Support
+- **Tool Call Visualization**: Graphical representation of tool call chains
+- **Cross-Tool Failure Analysis**: Identify failures at tool boundaries
+- **Tool Performance Metrics**: Latency, reliability, and cost per tool
+- **Tool Recommendation Engine**: Suggest better tool configurations
+
+## Evolution Path
+
+This design philosophy supports Arc's evolution from CLI to potential GUI:
+- **Playground Mode**: Interactive prompt refinement
+- **Trace Comparison**: Visual diff of execution paths
+- **Dataset Expansion**: Easy addition of edge cases
+- **Collaborative Features**: Team-based evaluation
+- **RL Integration**: Continuous learning from accepted improvements
+
+By following these principles, Arc's CLI becomes not just a testing tool, but a comprehensive capability assurance platform that guides users from discovering hidden assumptions to implementing proven fixes through continuous improvement cycles.

--- a/arc/cli/IMPLEMENTATION_PLAN.md
+++ b/arc/cli/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,236 @@
+# Arc Enterprise CLI Implementation Plan
+
+## Overview
+Implement enterprise-grade CLI interface that transforms technical output into actionable business insights, focusing on assumption validation and rapid iteration cycles.
+
+## Phase 1: Foundation (1 hour)
+
+### 1. Design Standards Module (`arc/cli/design_standards.py`)
+```python
+# Core visual identity and layout standards
+COLORS = {
+    'primary': 'bright_blue',      # Headers, Arc branding
+    'success': 'bright_green',     # Improvements, positive metrics  
+    'warning': 'bright_yellow',    # Attention items, assumptions
+    'error': 'bright_red',         # Failures, critical issues
+    'info': 'bright_cyan',         # Statistical data
+    'muted': 'bright_black',       # Secondary text
+    'accent': 'bright_magenta',    # Highlights, key values
+}
+
+LAYOUT = {
+    'terminal_width': 120,
+    'progress_bar_width': 40,
+    'panel_padding': (0, 1),
+    'assumption_highlight': 'bold bright_yellow',  # For surfacing hidden assumptions
+}
+
+# Progress indicators for real-time feedback
+PROGRESS_STYLES = {
+    'scenario_generation': SpinnerColumn() + TextColumn(),
+    'execution': BarColumn() + TimeRemainingColumn(),
+    'analysis': SpinnerColumn() + TextColumn("[progress.description]{task.description}"),
+}
+```
+
+### 2. Enterprise Messaging (`arc/cli/enterprise_messaging.py`)
+```python
+# Assumption-focused messaging
+ASSUMPTION_MESSAGES = {
+    'currency': "ASSUMPTION VIOLATED: Agent assumes {default_currency} for all transactions",
+    'language': "ASSUMPTION VIOLATED: Agent only handles {default_language} input",
+    'timezone': "ASSUMPTION VIOLATED: Agent uses {default_timezone} without validation",
+}
+
+# Action-oriented messages
+ACTION_MESSAGES = {
+    'infrastructure_fix': "INFRASTRUCTURE FIX: {description} resolves {percentage}% of failures",
+    'model_switch': "MODEL OPTIMIZATION: Switch to {model} for {cost_reduction}% cost savings",
+    'config_change': "CONFIGURATION FIX: {change} improves reliability by {improvement} pp",
+}
+
+# Business impact translations
+IMPACT_MESSAGES = {
+    'incident_prevention': "${amount:,} in prevented incidents per month",
+    'time_savings': "{hours} engineering hours saved vs reactive debugging",
+    'trust_impact': "{percentage}% reduction in customer-facing errors",
+}
+```
+
+### 3. Console Enhancement (`arc/cli/utils/console.py`)
+Update existing ArcConsole class:
+- Remove emoji usage (✓ → "PASS", ✗ → "FAIL")
+- Add assumption highlighting methods
+- Add funnel visualization helpers
+- Add statistical formatting (p-values, CI)
+
+## Phase 2: Multi-Model Intelligence (1 hour)
+
+### 4. Model Recommendation Engine (`arc/recommendations/model_optimizer.py`)
+```python
+class ModelOptimizer:
+    """Infrastructure-first approach to model selection"""
+    
+    def analyze_for_assumptions(self, failures: List[Failure]) -> AssumptionReport:
+        """Identify if failures are due to model limitations or config assumptions"""
+        # Decompose failures by type
+        # Separate model issues from infrastructure issues
+        # Prioritize config fixes over model changes
+    
+    def recommend_model_if_needed(self, current_perf: Performance) -> Optional[ModelRec]:
+        """Only recommend model change if config fixes won't solve the problem"""
+        # Check if infrastructure fixes available first
+        # Calculate cost/performance tradeoffs
+        # Include confidence based on test coverage
+```
+
+### 5. Failure Decomposition (`arc/analysis/funnel_analyzer.py`)
+```python
+class FunnelAnalyzer:
+    """Decompose agent execution into measurable steps"""
+    
+    def build_capability_funnel(self, trajectories: List[Trajectory]) -> Funnel:
+        """Create step-by-step success funnel"""
+        # Extract execution steps
+        # Calculate success rate at each step
+        # Identify bottleneck steps
+        
+    def find_assumption_violations(self, funnel: Funnel) -> List[Assumption]:
+        """Identify hidden assumptions causing failures"""
+        # Pattern match for common assumptions
+        # Extract minimal reproductions
+        # Group by assumption type
+```
+
+## Phase 3: Command Updates (2 hours)
+
+### 6. Enhanced Command Outputs
+
+#### `arc run` - Proactive Discovery Focus
+- Real-time assumption violation detection
+- Running count of "issues found BEFORE production"
+- Capability funnel preview
+- Infrastructure vs model issue breakdown
+
+#### `arc analyze` - Origin of Failure Focus  
+- Capability funnel visualization
+- Assumption violation clustering
+- Minimal reproduction with complexity reduction
+- "Why" before "what" in failure reporting
+
+#### `arc recommend` - Action Priority Focus
+- Infrastructure fixes first (config, prompts, tools)
+- Model changes only when necessary
+- Implementation time estimates
+- Confidence scores based on similar fixes
+
+#### `arc diff` - Assumption Validation Focus
+- Before/after assumption handling
+- Statistical validation of improvements
+- Funnel comparison (where improvements happened)
+- Business impact quantification
+
+#### `arc status` - Measurement Dashboard
+- Assumption violation trends
+- Infrastructure vs model fix ratio
+- Time-to-fix metrics
+- Cumulative value delivered
+
+### 7. Error Handling (`arc/cli/error_handlers.py`)
+- Actionable error messages
+- Suggest infrastructure fixes first
+- Link errors to assumptions
+- Provide fallback options
+
+## Implementation Order
+
+1. **Hour 1**: Foundation
+   - Design standards
+   - Enterprise messaging
+   - Console utilities update
+
+2. **Hour 2**: Intelligence Layer
+   - Model optimizer (infrastructure-first)
+   - Funnel analyzer
+   - Assumption detector
+
+3. **Hour 3**: Command Updates
+   - Update run command
+   - Update analyze command
+   - Update recommend command
+
+4. **Hour 4**: Polish & Testing
+   - Update diff and status commands
+   - Error handling
+   - Integration testing
+   - Demo preparation
+
+## Key Integration Points
+
+### With Database (Issue #37)
+- Store assumption violations for pattern learning
+- Track which fixes actually worked
+- Build historical funnel data
+
+### With Modal (Issue #5)
+- Real-time funnel updates during execution
+- Stream assumption violations as discovered
+- Cost tracking with ROI calculation
+
+### With Scenario Generation (Issue #7)
+- Generate scenarios targeting discovered assumptions
+- Test assumption fixes specifically
+- Validate infrastructure improvements
+
+## Success Criteria
+
+1. **Assumption Visibility**: Hidden assumptions surface within first run
+2. **Action Clarity**: Every output includes specific next step
+3. **Infrastructure First**: 80% of fixes are config/prompt changes
+4. **Rapid Iteration**: < 5 min from problem to validated fix
+5. **Business Translation**: Every technical metric has dollar impact
+
+## Demo Script Integration
+
+```bash
+# Shows assumption discovery
+arc run finance_agent_v1.yaml
+# "PROACTIVE DISCOVERY: 12 currency assumption violations found BEFORE production"
+
+# Shows failure decomposition  
+arc analyze
+# "FUNNEL ANALYSIS: 86% of failures occur at currency parsing step"
+
+# Shows infrastructure-first fix
+arc recommend  
+# "INFRASTRUCTURE FIX: Add currency validation to prompt (10 min implementation)"
+
+# Shows validated improvement
+arc diff finance_agent_v1.yaml finance_agent_v2.yaml
+# "ASSUMPTION FIXED: Currency handling improved by 91.7%"
+```
+
+## Files to Create/Modify
+
+**New Files:**
+- `arc/cli/design_standards.py`
+- `arc/cli/enterprise_messaging.py`
+- `arc/recommendations/model_optimizer.py`
+- `arc/analysis/funnel_analyzer.py`
+- `arc/cli/error_handlers.py`
+
+**Modified Files:**
+- `arc/cli/utils/console.py` (remove emojis, add methods)
+- `arc/cli/commands/run.py` (new output format)
+- `arc/cli/commands/analyze.py` (funnel visualization)
+- `arc/cli/commands/recommend.py` (infrastructure-first)
+- `arc/cli/commands/diff.py` (assumption validation)
+- `arc/cli/commands/status.py` (measurement dashboard)
+
+## Testing Focus
+
+1. **Assumption Detection**: Verify currency assumptions surface clearly
+2. **Funnel Accuracy**: Steps decompose meaningfully
+3. **Action Validation**: Recommendations are implementable
+4. **Statistical Rigor**: All claims have valid backing
+5. **Performance**: Real-time updates work smoothly

--- a/arc/cli/TODO.md
+++ b/arc/cli/TODO.md
@@ -1,0 +1,104 @@
+# Enterprise CLI Implementation TODO
+
+## Quick Reference Checklist
+
+### Phase 1: Foundation (Hour 1)
+- [ ] Create `arc/cli/design_standards.py`
+  - [ ] Define color palette (no emojis)
+  - [ ] Set layout standards
+  - [ ] Create progress indicator styles
+  - [ ] Add assumption highlighting styles
+
+- [ ] Create `arc/cli/enterprise_messaging.py`
+  - [ ] Assumption violation messages
+  - [ ] Action-oriented messages
+  - [ ] Business impact translations
+  - [ ] Statistical credibility messages
+
+- [ ] Update `arc/cli/utils/console.py`
+  - [ ] Remove emoji usage (✓ → "PASS", ✗ → "FAIL") 
+  - [ ] Add format_assumption() method
+  - [ ] Add format_funnel() method
+  - [ ] Add format_statistical() method
+  - [ ] Fix import structure for design standards
+
+### Phase 2: Multi-Model Intelligence (Hour 2)
+- [ ] Create `arc/recommendations/model_optimizer.py`
+  - [ ] Import from experiments/generation/generator.py
+  - [ ] Infrastructure-first recommendation logic
+  - [ ] Cost/performance analysis
+  - [ ] Confidence scoring
+
+- [ ] Create `arc/analysis/funnel_analyzer.py`
+  - [ ] Capability decomposition
+  - [ ] Step success rate calculation
+  - [ ] Assumption violation detection
+  - [ ] Minimal reproduction generation
+
+### Phase 3: Command Updates (Hour 3)
+- [ ] Update `arc/cli/commands/run.py`
+  - [ ] Real-time assumption detection display
+  - [ ] Proactive value messaging
+  - [ ] Capability funnel preview
+  - [ ] Cost tracking display
+
+- [ ] Update `arc/cli/commands/analyze.py`
+  - [ ] Funnel visualization
+  - [ ] Assumption clustering
+  - [ ] Origin of failure focus
+  - [ ] Minimal reproduction display
+
+- [ ] Update `arc/cli/commands/recommend.py`
+  - [ ] Infrastructure fixes first
+  - [ ] Multi-model recommendations
+  - [ ] Implementation time estimates
+  - [ ] Confidence scores
+
+### Phase 4: Polish & Testing (Hour 4)
+- [ ] Update `arc/cli/commands/diff.py`
+  - [ ] Assumption validation display
+  - [ ] Funnel comparison
+  - [ ] Enhanced statistical display
+
+- [ ] Update `arc/cli/commands/status.py`
+  - [ ] Measurement dashboard
+  - [ ] Assumption trends
+  - [ ] Fix type breakdown
+
+- [ ] Create `arc/cli/error_handlers.py`
+  - [ ] Actionable error formatting
+  - [ ] Infrastructure-first suggestions
+  - [ ] Fallback options
+
+- [ ] Integration testing
+  - [ ] Test with finance_agent configs
+  - [ ] Verify 73% → 91% flow
+  - [ ] Check all messaging
+  - [ ] Validate real-time updates
+
+## Key Files to Reference
+- `experiments/generation/multi_model_tester.py` - Multi-model testing
+- `experiments/generation/generator.py` (lines 24-52) - Model costs
+- `examples/configs/finance_agent_v1.yaml` - Test config
+- `examples/configs/finance_agent_v2.yaml` - Improved config
+
+## Design Principles Checklist
+- [ ] Every failure shows its origin, not just outcome
+- [ ] Infrastructure fixes prioritized over model changes
+- [ ] All improvements quantified with statistical backing
+- [ ] Business impact translated from technical metrics
+- [ ] Next action always clear and specific
+- [ ] 5-minute problem-to-fix cycle achieved
+
+## Demo Validation
+- [ ] Currency assumption violations surface clearly
+- [ ] Funnel shows where failures occur
+- [ ] Recommendations are actionable
+- [ ] Statistical validation is credible
+- [ ] Business value is apparent
+
+## Git Commits
+- [ ] Phase 1: "feat: Add enterprise CLI design standards and messaging"
+- [ ] Phase 2: "feat: Add multi-model optimizer and funnel analyzer"  
+- [ ] Phase 3: "feat: Update CLI commands with enterprise interface"
+- [ ] Phase 4: "feat: Add error handling and polish interface"


### PR DESCRIPTION
## Summary
- Extract design documentation from PR #41 before closing it
- Add enterprise CLI design philosophy, implementation plan, and TODO documents
- No code changes, only documentation

## Context
PR #41 claims to implement enterprise CLI features but only contains documentation files. This PR extracts those valuable design documents so we can:
1. Close PR #41 as incomplete
2. Rebuild the UI design based on these docs using our latest implementation with TimescaleDB and Modal integration

## Files Added
- `arc/cli/ENTERPRISE_CLI_DESIGN_PHILOSOPHY.md` - Core design principles and workflow
- `arc/cli/IMPLEMENTATION_PLAN.md` - Phased implementation approach
- `arc/cli/TODO.md` - Detailed task breakdown

## Next Steps
After merging this PR:
1. Close PR #41
2. Create new implementation based on these design docs that incorporates our current database and Modal infrastructure

🤖 Generated with [Claude Code](https://claude.ai/code)